### PR TITLE
upgrade off square master

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -7,6 +7,7 @@ require 'capistrano/deploy'
 # Includes tasks from other gems included in your Gemfile
 require 'capistrano/bundler'
 require 'capistrano/rails'
+require 'capistrano/rvm'
 
 # If you would like to use a Ruby version manager with kochiku
 # require it from a .cap file in lib/capistrano/tasks/.

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'nokogiri'
 gem 'pry-rails'
 gem 'pry-byebug'
 
+# Iora uses thin as our prod server
+gem 'thin'
+
 group :test, :development do
   gem 'haml_lint', require: false
   gem 'rubocop', require: false
@@ -55,7 +58,6 @@ group :development do
   gem 'capistrano-bundler', '~> 1.1', require: false
   gem 'quiet_assets'
   gem 'capistrano-rvm', '~> 0.1', require: false
-  gem 'thin'
   gem 'rails-erd'
 end
 

--- a/app/controllers/build_artifacts_controller.rb
+++ b/app/controllers/build_artifacts_controller.rb
@@ -18,6 +18,10 @@ class BuildArtifactsController < ApplicationController
   def show
     build_artifact = BuildArtifact.find(params[:id])
 
-    redirect_to build_artifact.log_file.url
+    if params[:format] == 'text'
+      render text: build_artifact.log_contents
+    else
+      redirect_to build_artifact.log_file.url
+    end
   end
 end

--- a/app/helpers/build_parts_helper.rb
+++ b/app/helpers/build_parts_helper.rb
@@ -1,0 +1,9 @@
+module BuildPartsHelper
+  def basename_with_extension(path)
+    File.basename(path)
+  end
+
+  def basename_without_extension(path)
+    File.basename(path, File.extname(path))
+  end
+end

--- a/app/models/build_artifact.rb
+++ b/app/models/build_artifact.rb
@@ -8,4 +8,12 @@ class BuildArtifact < ActiveRecord::Base
 
   scope :stdout_log, -> { where(:log_file => ['stdout.log.gz', 'stdout.log']) }
   scope :error_txt, -> { where(:log_file => 'error.txt') }
+
+  def log_contents
+    if log_file.path.include? '.gz'
+      Zlib::GzipReader.new(open(log_file.path)).read
+    else
+      log_file.read
+    end
+  end
 end

--- a/app/models/repository_observer.rb
+++ b/app/models/repository_observer.rb
@@ -6,6 +6,7 @@ class RepositoryObserver < ActiveRecord::Observer
   end
 
   def setup_hook?
+    return false ## ALEX DOES NOT HAVE CREDENTIALS FOR GITHUB HOOKS
     Rails.env.production? || Rails.env.staging?
   end
 end

--- a/app/views/build_parts/show.html.haml
+++ b/app/views/build_parts/show.html.haml
@@ -52,7 +52,10 @@
             = link_to("stdout.log (in progress)", stream_logs_path(attempt.id))
           - else
             - attempt.build_artifacts.each do |artifact|
-              = link_to File.basename(artifact.log_file.path), artifact
+              = link_to basename_without_extension(artifact.log_file.path), build_artifact_path(artifact, format: :text)
+              (
+              = link_to 'gzipped', build_artifact_path(artifact)
+              )
               %br
         %td.wrap
           - unless attempt.stopped?

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,4 +1,35 @@
-# Place your production Kochiku application config here.
-#
-# Start by copying the contents of config/application.dev.yml and modify as
-# desired.
+# Email address to use in the 'from' field for emails sent by Kochiku.
+sender_email_address: 'kochiku@icisapp.com'
+
+# Email address where kochiku should send problems with the build system (for example, errors),
+# as distinct from failures in a particular test (which go to the people who committed code).
+kochiku_notifications_email_address: 'kochiku-notifications@icisapp.com'
+
+# Domain name to use in constructing generic addresses. For example noreply@example.com in git commits.
+domain_name: 'icisapp.com'
+
+# Set to true if Kochiku is served over https
+use_https: true
+
+# Host name where Kochiku is serving web pages.
+kochiku_host: 'kochiku.icisapp.com'
+
+# If you commit with hitch/git-pair, etc, set this in order to send email to each person in the pair.
+# For example, github+joe+bob@example.com will turn into emails to joe@example.com and bob@example.com
+# if git_pair_email_prefix is set to 'github'.
+git_pair_email_prefix: 'github'
+
+# Mail server which will accept mail on port 25 (standard SMTP port). If you need to use another port,
+# or other settings, you currently need to edit the kochiku source (config.action_mailer settings in
+# config/environments/production.rb).
+smtp_server: 'localhost'
+
+# Host and port to connect to for Redis communication.
+redis_host: '127.0.0.1'
+redis_port: 6379
+
+# List your git servers
+git_servers:
+  github.com:
+    type: github
+    oauth_token_file: /app/kochiku/secrets/kochiku-github-oauth

--- a/config/deploy/iora.rb
+++ b/config/deploy/iora.rb
@@ -1,0 +1,8 @@
+server 'newkochiku.icisapp.com', user: 'ops', roles: %w{web app db worker}
+set :deploy_to, "/home/ops/kochiku-master"
+set :rails_env, 'production'
+set :repo_url, "git://github.com/IoraHealth/kochiku.git"
+set :branch, 'square-master'
+set :rvm_ruby_version, '2.3.0'
+
+after  "deploy:publishing", "deploy:restart"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Kochiku::Application.configure do
   }
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS
   config.assets.js_compressor = :uglifier

--- a/iora.md
+++ b/iora.md
@@ -1,0 +1,33 @@
+# On master server
+
+* Cleanup bad builds
+  - same sha built as part of 2 different "projects" - ie alexs_macbook & pull_request
+
+    Build.find(1714, 5352, 6805, 6832, 6956, 8303, 7868, 8506, 7529, 7611, 8343, 7346, 8022, 7979, 7265, 8371, 8541, 7893, 7645, 8207, 7988).each &:destroy
+
+* Password secret config in shared
+    mkdir /home/ops/kochiku-master/shared/config
+    cp /home/ops/kochiku-master/current/config/database.yml /home/ops/kochiku-master/shared/config
+
+* Might need to do these in kochiku-ops - need to test a new clean upgrade
+
+    sudo yum downgrade libyaml-0.1.3-4.el6_6
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+
+(see https://github.com/rvm/rvm/issues/3347 for an explanation of the yum downgrade step)
+
+# INSTALL
+
+On devops laptop
+
+```
+cd kochiku
+cap iora deploy
+```
+
+```
+cd kochiku-worker
+cap iora deploy
+```
+
+

--- a/lib/capistrano/tasks/deploy.cap
+++ b/lib/capistrano/tasks/deploy.cap
@@ -34,7 +34,7 @@ namespace :deploy do
 
   task :overwrite_database_yml do
     on roles(:app) do |host|
-      execute :mv, "#{release_path}/config/database.production.yml", "#{release_path}/config/database.yml"
+      execute :ln, '-nfFs', shared_path.join('config/database.yml'), release_path.join('config')
     end
   end
 end

--- a/lib/capistrano/tasks/iora.cap
+++ b/lib/capistrano/tasks/iora.cap
@@ -1,0 +1,12 @@
+namespace :deploy do
+  task :restart do
+    on roles(:app) do
+      within current_path do
+        flags = "-P #{shared_path.join('pids/thin.pid')} -e production -p 8080 -d -l logs/thin.log"
+        # execute  :thin, "stop #{flags}"
+        # sleep 5
+        execute :bundle, "exec thin restart #{flags}"
+      end
+    end
+  end
+end

--- a/spec/helpers/build_parts_helper_spec.rb
+++ b/spec/helpers/build_parts_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe BuildPartsHelper do
+  let(:test_log_gz) { '/some/path/to/test.log.gz' }
+
+  describe "#basename_with_extension" do
+    it 'returns the basename with the extension' do
+      expect(helper.basename_with_extension(test_log_gz)).to eq("test.log.gz")
+    end
+  end
+
+  describe "#basename_without_extension" do
+    it 'returns the basename without the extension' do
+      expect(helper.basename_without_extension(test_log_gz)).to eq("test.log")
+    end
+  end
+end

--- a/spec/models/build_artifact_spec.rb
+++ b/spec/models/build_artifact_spec.rb
@@ -20,4 +20,20 @@ describe BuildArtifact do
       should include(stdout_artifact)
     end
   end
+
+  describe "#log_contents" do
+    let!(:artifact)       { FactoryGirl.create :build_artifact }
+    let!(:artifact_gz) { FactoryGirl.create :build_artifact, :log_file => File.open(FIXTURE_PATH + 'stdout.log.gz') }
+
+    it "should return the log contents for a log" do
+      log_contents = artifact.log_file.read
+      expect(artifact.log_contents).to eq(log_contents)
+    end
+
+    it "should return the log contents for a gzipped log" do
+      infile = open(artifact_gz.log_file.path)
+      log_contents = Zlib::GzipReader.new(infile).read
+      expect(artifact_gz.log_contents).to eq(log_contents)
+    end
+  end
 end


### PR DESCRIPTION
This is based off square/master so brings up up to date with the latest kochiku.  Primarily including streaming logs so you don't have to wait for a build to finish before seeing the log. Also whatever else square has been doing to improve kochiku in the past 2 years.

There are 2 commits
1. A series of iora specific configurations so we can deploy and run it on our infrastructure
2. An update to @eliotk's plain text log work we've been running on our branch.  I submitted a pull upstream for this square/kochiku#234

To merge we will not want to merge onto master but I think reset master to this and do a force push.  Saving the current master on a branch first.
